### PR TITLE
Feature/soft delete member

### DIFF
--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
@@ -103,7 +103,17 @@ public class AuthController {
                                                               @Valid @RequestBody PasswordChangeDto dto,
                                                               @AuthenticationPrincipal Member member) {
         authService.changePassword(member, dto);
-        logout(accessTokenHeader, refreshTokenHeader);
+        authService.logout(accessTokenHeader, refreshTokenHeader);
         return ApiResponse.success(HttpStatus.OK, "비밀번호를 성공적으로 변경하였습니다. 재로그인하시기 바랍니다.");
+    }
+
+    @DeleteMapping("/delete")
+    @CheckAuthenticatedUser
+    public ResponseEntity<Void> withdrawMember(@RequestHeader("Authorization") String accessTokenHeader,
+                                               @RequestHeader("Refresh-Token") String refreshTokenHeader,
+                                               @AuthenticationPrincipal Member member) {
+        authService.withdraw(member);
+        authService.logout(accessTokenHeader, refreshTokenHeader);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
@@ -48,13 +48,8 @@ public class AuthController {
     public ResponseEntity<ApiResponse<String>> logout(@RequestHeader("Authorization") String accessTokenHeader,
                                                       @RequestHeader("Refresh-Token") String refreshTokenHeader) {
 
-        if (accessTokenHeader == null || !accessTokenHeader.startsWith("Bearer ") ||
-                refreshTokenHeader == null || !refreshTokenHeader.startsWith("Bearer ")) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
-        }
-
-        String accessToken = accessTokenHeader.substring(7).trim();
-        String refreshToken = refreshTokenHeader.substring(7).trim();
+        String accessToken = extractToken(accessTokenHeader);
+        String refreshToken = extractToken(refreshTokenHeader);
 
         if (!jwtTokenProvider.validateToken(accessToken) || !jwtTokenProvider.validateToken(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
@@ -103,7 +98,7 @@ public class AuthController {
                                                               @Valid @RequestBody PasswordChangeDto dto,
                                                               @AuthenticationPrincipal Member member) {
         authService.changePassword(member, dto);
-        authService.logout(accessTokenHeader, refreshTokenHeader);
+        logout(accessTokenHeader, refreshTokenHeader);
         return ApiResponse.success(HttpStatus.OK, "비밀번호를 성공적으로 변경하였습니다. 재로그인하시기 바랍니다.");
     }
 
@@ -112,8 +107,19 @@ public class AuthController {
     public ResponseEntity<Void> withdrawMember(@RequestHeader("Authorization") String accessTokenHeader,
                                                @RequestHeader("Refresh-Token") String refreshTokenHeader,
                                                @AuthenticationPrincipal Member member) {
-        authService.withdraw(member);
-        authService.logout(accessTokenHeader, refreshTokenHeader);
+
+        String accessToken = extractToken(accessTokenHeader);
+        String refreshToken = extractToken(refreshTokenHeader);
+
+        authService.withdraw(member, accessToken, refreshToken);
+
         return ResponseEntity.noContent().build();
+    }
+
+    private String extractToken(String header) {
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+        return header.substring(7).trim();
     }
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/entity/Member.java
@@ -65,6 +65,10 @@ public class Member implements UserDetails {
     @Builder.Default
     private List<String> roles = new ArrayList<>();
 
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DayRecord> dayRecords = new ArrayList<>();
 
@@ -80,6 +84,9 @@ public class Member implements UserDetails {
         dayRecord.assignMember(this);
     }
 
+    public void withdraw() {
+        this.isDeleted = true;
+    }
 
     @Override
     public String getUsername() {

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -92,8 +92,11 @@ public class AuthService {
         String password = loginRequestDto.getPassword();
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, password);
 
-        if (!isLoginIdAlreadyExist(id)) {
-            throw new LoginException(ErrorCode.USER_NOT_FOUND, "아이디가 존재하지 않습니다.");
+        Member member = memberRepository.findByLoginId(id)
+                .orElseThrow(() -> new LoginException(ErrorCode.USER_NOT_FOUND, "아이디가 존재하지 않습니다."));
+
+        if (member.isDeleted()) {
+            throw new LoginException(ErrorCode.ALREADY_DELETED, "탈퇴한 회원입니다.");
         }
 
         try {

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -264,4 +264,23 @@ public class AuthService {
             throw new CustomException(ErrorCode.INVALID_INPUT, "유효하지 않은 입력값입니다.");
         }
     }
+
+    @Transactional
+    public void withdraw(Member member) {
+        try {
+            Member persistedMember = memberRepository.findById(member.getId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "회원 정보를 찾을 수 없습니다."));
+
+            if (persistedMember.isDeleted()) {
+                throw new CustomException(ErrorCode.ALREADY_DELETED);
+            }
+            persistedMember.withdraw();
+            memberRepository.flush();
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("회원 탈퇴 중 에러 발생: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.UNKNOWN_ERROR, "회원 탈퇴 중 오류가 발생했습니다.");
+        }
+    }
 }

--- a/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     WRONG_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     PASSWORD_MISMATCH("변경할 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     SAME_PASSWORD("변경할 비밀번호는 기존의 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_DELETED("탈퇴한 계정입니다.", HttpStatus.BAD_REQUEST),
 
     // 토큰
     INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #15 

### 🙌 작업 내용
- 회웥탈퇴를 구현했습니다.
- 회원탈퇴는 soft delete 방식을 이용합니다.
- 회원탈퇴 로직 수행 후 로그아웃을 수행하여 토큰을 무효화합니다.
- 탈퇴한 계정이 사용한 아이디, 이메일은 추후 회원가입 시  사용 불가합니다.

### 📸 스크린샷 (선택)
- 성공 
![회원탈퇴 성공](https://github.com/user-attachments/assets/b2d67552-ed2e-4b69-9b4d-0f74c94f96b0)

- 실패 : 로그아웃된 토큰으로 시도 시(이미 탈퇴 성공했는데 재시도한 경우) 
![실패](https://github.com/user-attachments/assets/95d71cc4-7f9d-402a-becb-f724513afacc)

- 탈퇴한 계정으로 로그인 시도 시 400 에러를 반환합니다.
![image](https://github.com/user-attachments/assets/660ec538-b90e-466d-80f3-a6559203aadc)

