### PR TITLE
refactor: 로그아웃 로직 처리를 서비스 단에서 하도록 수정

### DIFF
--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
@@ -97,10 +97,12 @@ public class AuthController {
                                                               @RequestHeader("Refresh-Token") String refreshTokenHeader,
                                                               @Valid @RequestBody PasswordChangeDto dto,
                                                               @AuthenticationPrincipal Member member) {
-        authService.changePassword(member, dto);
-        logout(accessTokenHeader, refreshTokenHeader);
+        String accessToken = extractToken(accessTokenHeader);
+        String refreshToken = extractToken(refreshTokenHeader);
+        authService.changePasswordAndLogout(member, dto,accessToken, refreshToken);
         return ApiResponse.success(HttpStatus.OK, "비밀번호를 성공적으로 변경하였습니다. 재로그인하시기 바랍니다.");
     }
+
 
     @DeleteMapping("/delete")
     @CheckAuthenticatedUser

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -166,6 +166,12 @@ public class AuthService {
     }
 
     @Transactional
+    public void changePasswordAndLogout(Member member, PasswordChangeDto dto, String accessToken, String refreshToken) {
+        changePassword(member, dto);
+        logout(accessToken, refreshToken);
+    }
+
+    @Transactional
     public void changePassword(Member member, PasswordChangeDto dto) {
         try {
             validateOldPassword(member, dto.getOldPassword());
@@ -186,6 +192,7 @@ public class AuthService {
             throw new CustomException(ErrorCode.UNKNOWN_ERROR, "비밀번호 변경 중 오류가 발생했습니다.");
         }
     }
+
 
     private void validatePasswordSame(String oldPassword, String newPassword) {
         if (newPassword.equals(oldPassword)) {


### PR DESCRIPTION
### 🙌 작업 내용
- 비밀번호 변경 시 로그아웃을 수행하는 위치를 변경함.
- 실제 행동을 서비스 단에서 하도록 수정

### 📸 스크린샷 (선택)
- 실패 : 현재 비밀번호 불일치
![현재 비밀번호 틀림](https://github.com/user-attachments/assets/21819cc6-fba4-4f0f-8be5-38b70d5c7668)

- 실패 : 변경할 비밀번호를 잘못 입력 (비밀번호 재입력 실패)
![비밀번호 재입력 불일치](https://github.com/user-attachments/assets/61524dc9-513e-45b6-b88d-c3f07e6663fe)

- 실패 : 현재와 동일한 비밀번호로 변경 시도
![동일한 비밀번호](https://github.com/user-attachments/assets/ac788649-1578-4c14-a100-120b6b12131f)

- 실패 : 비밀번호 조건 미충족 
![로직 미충족](https://github.com/user-attachments/assets/8a0ab72b-28d7-4822-adfe-890f059d0918)

- 성공 -> 로그아웃됨
![성공](https://github.com/user-attachments/assets/ffd19d68-49c5-4e6b-a4c5-e0d01707f64f)
![토큰 재사용 불가](https://github.com/user-attachments/assets/e54c0855-adb7-4b33-adf9-1b2a88441e63)
