### PR TITLE
Feature/reset password

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.data:spring-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.data:spring-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
@@ -1,9 +1,6 @@
 package com.howWeather.howWeather_backend.domain.member.api;
 
-import com.howWeather.howWeather_backend.domain.member.dto.DuplicateCheckDto;
-import com.howWeather.howWeather_backend.domain.member.dto.LoginRequestDto;
-import com.howWeather.howWeather_backend.domain.member.dto.PasswordChangeDto;
-import com.howWeather.howWeather_backend.domain.member.dto.SignupRequestDto;
+import com.howWeather.howWeather_backend.domain.member.dto.*;
 import com.howWeather.howWeather_backend.domain.member.entity.Member;
 import com.howWeather.howWeather_backend.domain.member.service.AuthService;
 import com.howWeather.howWeather_backend.global.Response.ApiResponse;
@@ -116,6 +113,12 @@ public class AuthController {
         authService.withdraw(member, accessToken, refreshToken);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse<String>> resetPassword(@Valid @RequestBody PasswordResetRequestDto dto) {
+        authService.resetPassword(dto.getIdentifier());
+        return ApiResponse.success(HttpStatus.OK, "임시 비밀번호를 이메일로 전송했습니다.");
     }
 
     private String extractToken(String header) {

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
@@ -117,9 +117,10 @@ public class AuthController {
 
     @PostMapping("/reset-password")
     public ResponseEntity<ApiResponse<String>> resetPassword(@Valid @RequestBody PasswordResetRequestDto dto) {
-        authService.resetPassword(dto.getIdentifier());
-        return ApiResponse.success(HttpStatus.OK, "임시 비밀번호를 이메일로 전송했습니다.");
+        String email = authService.resetPassword(dto.getIdentifier());
+        return ApiResponse.success(HttpStatus.OK, email);
     }
+
 
     private String extractToken(String header) {
         if (header == null || !header.startsWith("Bearer ")) {

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/PasswordResetRequestDto.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/PasswordResetRequestDto.java
@@ -1,0 +1,10 @@
+package com.howWeather.howWeather_backend.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class PasswordResetRequestDto {
+    @NotBlank(message = "아이디 또는 이메일을 입력해야 합니다.")
+    private String identifier;
+}

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/PasswordResetRequestDto.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/PasswordResetRequestDto.java
@@ -2,8 +2,10 @@ package com.howWeather.howWeather_backend.domain.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import lombok.Getter;
 
 @Data
+@Getter
 public class PasswordResetRequestDto {
     @NotBlank(message = "아이디 또는 이메일을 입력해야 합니다.")
     private String identifier;

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByLoginId(String loginId);
+
+    Optional<Member> findByUsernameOrEmail(String username, String email);
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
@@ -12,5 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByLoginId(String loginId);
 
-    Optional<Member> findByUsernameOrEmail(String username, String email);
+    Optional<Member> findByLoginIdOrEmail(String loginId, String email);
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -310,7 +310,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void resetPassword(String identifier) {
+    public String resetPassword(String identifier) {
         try {
             Member member = memberRepository.findByLoginIdOrEmail(identifier, identifier)
                     .orElseThrow(() -> new CustomException(ErrorCode.ID_OR_EMAIL_NOT_FOUND));
@@ -322,6 +322,7 @@ public class AuthService {
 
             memberRepository.flush();
             mailService.sendTemporaryPassword(member.getEmail(), tempPassword);
+            return member.getEmail();
         }  catch (CustomException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -39,6 +39,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordGeneratorService passwordGeneratorService;
     private final ClosetRepository closetRepository;
+    private final MailService mailService;
 
     @Transactional
     public void signup(SignupRequestDto signupRequestDto) {
@@ -319,6 +320,7 @@ public class AuthService {
         member.changePassword(encoded);
 
         memberRepository.flush();
+        mailService.sendTemporaryPassword(member.getEmail(), tempPassword);
     }
 
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -311,7 +311,7 @@ public class AuthService {
 
     @Transactional
     public void resetPassword(String identifier) {
-        Member member = memberRepository.findByUsernameOrEmail(identifier, identifier)
+        Member member = memberRepository.findByLoginIdOrEmail(identifier, identifier)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
         String tempPassword = passwordGeneratorService.generateSecurePassword(12);

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -23,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.SecureRandom;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordGeneratorService passwordGeneratorService;
     private final ClosetRepository closetRepository;
 
     @Transactional
@@ -305,4 +307,18 @@ public class AuthService {
             throw new CustomException(ErrorCode.UNKNOWN_ERROR, "회원 탈퇴 중 오류가 발생했습니다.");
         }
     }
+
+    @Transactional
+    public void resetPassword(String identifier) {
+        Member member = memberRepository.findByUsernameOrEmail(identifier, identifier)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        String tempPassword = passwordGeneratorService.generateSecurePassword(12);
+
+        String encoded = passwordEncoder.encode(tempPassword);
+        member.changePassword(encoded);
+
+        memberRepository.flush();
+    }
+
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/MailService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/MailService.java
@@ -1,0 +1,34 @@
+package com.howWeather.howWeather_backend.domain.member.service;
+
+import com.howWeather.howWeather_backend.global.exception.CustomException;
+import com.howWeather.howWeather_backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendTemporaryPassword(String toEmail, String tempPassword) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(toEmail);
+            message.setSubject("[YourApp] 임시 비밀번호 안내");
+            message.setText("안녕하세요,\n\n요청하신 임시 비밀번호는 아래와 같습니다.\n\n" +
+                    "임시 비밀번호: " + tempPassword + "\n\n" +
+                    "로그인 후 반드시 비밀번호를 변경해주세요.\n\n감사합니다.");
+
+            mailSender.send(message);
+            log.info("임시 비밀번호 이메일 전송 성공: {}", toEmail);
+        } catch (Exception e) {
+            log.error("임시 비밀번호 이메일 전송 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.EMAIL_SEND_FAIL);
+        }
+    }
+}

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/PasswordGeneratorService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/PasswordGeneratorService.java
@@ -9,7 +9,7 @@ public class PasswordGeneratorService {
     private static final String UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     private static final String LOWER = UPPER.toLowerCase();
     private static final String DIGITS = "0123456789";
-    private static final String SPECIALS = "!@#$%^&*()_+-=[]{};':\"\\|,.<>/?";
+    private static final String SPECIALS = "!@#$%^&*()-_+=";
 
     private static final String ALL = UPPER + LOWER + DIGITS + SPECIALS;
 

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/PasswordGeneratorService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/PasswordGeneratorService.java
@@ -1,0 +1,52 @@
+package com.howWeather.howWeather_backend.domain.member.service;
+
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+public class PasswordGeneratorService {
+    private static final String UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String LOWER = UPPER.toLowerCase();
+    private static final String DIGITS = "0123456789";
+    private static final String SPECIALS = "!@#$%^&*()_+-=[]{};':\"\\|,.<>/?";
+
+    private static final String ALL = UPPER + LOWER + DIGITS + SPECIALS;
+
+    private static final SecureRandom random = new SecureRandom();
+
+    public String generateSecurePassword(int length) {
+        if (length < 8) {
+            throw new IllegalArgumentException("비밀번호 길이는 최소 8자 이상이어야 합니다.");
+        }
+
+        StringBuilder password = new StringBuilder(length);
+
+        password.append(randomChar(UPPER));
+        password.append(randomChar(LOWER));
+        password.append(randomChar(DIGITS));
+        password.append(randomChar(SPECIALS));
+
+        for (int i = 4; i < length; i++) {
+            password.append(randomChar(ALL));
+        }
+
+        return shuffleString(password.toString());
+    }
+
+    private char randomChar(String chars) {
+        return chars.charAt(random.nextInt(chars.length()));
+    }
+
+    private String shuffleString(String input) {
+        char[] a = input.toCharArray();
+
+        for (int i = a.length - 1; i > 0; i--) {
+            int j = random.nextInt(i + 1);
+            char tmp = a[i];
+            a[i] = a[j];
+            a[j] = tmp;
+        }
+        return new String(a);
+    }
+}

--- a/src/main/java/com/howWeather/howWeather_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/howWeather/howWeather_backend/global/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeRequestsConfig)->
                         authorizeRequestsConfig
                                 .requestMatchers("/api/auth/email-exist-check", "/api/auth/login",
-                                        "/api/auth/signup", "/api/auth/loginid-exist-check").permitAll()
+                                        "/api/auth/signup", "/api/auth/loginid-exist-check", "/api/auth/reset-password").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(

--- a/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
     UNKNOWN_ERROR("서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_INPUT("입력 항목이 조건을 충족하지 않습니다", HttpStatus.BAD_REQUEST),
     
-    // 회원가입/로그인
+    // 회원가입/로그인/로그아웃/비밀번호 설정 관련
     USER_ALREADY_EXISTS("이미 존재하는 사용자입니다.", HttpStatus.BAD_REQUEST),
     USER_NOT_FOUND("아이디가 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_CREDENTIALS("비밀번호가 틀렸습니다.", HttpStatus.UNAUTHORIZED),
@@ -21,6 +21,7 @@ public enum ErrorCode {
     PASSWORD_MISMATCH("변경할 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     SAME_PASSWORD("변경할 비밀번호는 기존의 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED("탈퇴한 계정입니다.", HttpStatus.BAD_REQUEST),
+    EMAIL_SEND_FAIL("임시 비밀번호 이메일 전송에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
 
     // 토큰
     INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     SAME_PASSWORD("변경할 비밀번호는 기존의 비밀번호와 달라야 합니다.", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED("탈퇴한 계정입니다.", HttpStatus.BAD_REQUEST),
     EMAIL_SEND_FAIL("임시 비밀번호 이메일 전송에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    ID_OR_EMAIL_NOT_FOUND("해당 아이디나 이메일을 사용하는 계정이 없습니다", HttpStatus.NOT_FOUND),
 
     // 토큰
     INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/resources/templates/mail/temp-password.html
+++ b/src/main/resources/templates/mail/temp-password.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>[날씨어때]임시 비밀번호 안내</title>
+</head>
+<body style="font-family: 'Arial', sans-serif; font-size: 14px; color: #333; text-align: center;">
+<p>안녕하세요, 날씨어때 입니다.</p>
+<p>요청하신 <strong>임시 비밀번호</strong>는 아래와 같습니다.</p>
+<p style="display: inline-block; padding: 10px; background-color: #f2f2f2; border: 1px solid #ccc; font-size: 16px; font-weight: bold; width: fit-content;">
+    <span th:text="${tempPassword}">[임시 비밀번호]</span>
+</p>
+<p>로그인 후 반드시 <strong>비밀번호를 변경</strong>해주세요.</p>
+
+<p style="margin-top: 20px; color: #a00; font-weight: bold;">
+    ※ 만약 본인이 요청하지 않은 경우, 계정 정보가 노출되었을 가능성이 있습니다.<br/>
+    즉시 로그인 후 비밀번호를 변경해 주시기 바랍니다.<br/>
+    문제가 지속되면 고객센터로 문의해 주세요.
+</p>
+
+<br/>
+<p>감사합니다.<br/>날씨어때 팀 드림</p>
+</body>
+</html>


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #25 

### 🙌 작업 내용
- 비밀번호를 초기화합니다.
- 동작 로직은 다음과 같습니다.

1. 사용자의 이메일이나 아이디를 전달받음
2. 해당 계정 정보가 있는지 검색 -> 없을 경우 404 에러
3. 백에서 비밀번호 랜덤 생성해 재설정
4. 재설정된 비밀번호를 사용자가 회원가입 시 입력한 이메일로 전송

### 📸 스크린샷 (선택)
- 실패 : 없는 계정으로 시도
![404](https://github.com/user-attachments/assets/77e83bbb-8a4c-42b6-b35f-39ee137b78a7)

- 성공 시 [아이디 이용]
![image](https://github.com/user-attachments/assets/ceb899cb-d363-44b4-94af-e43076aa8c82)

- 성공 시 [이메일 이용]
![image](https://github.com/user-attachments/assets/d7365be1-507a-431d-b715-2e68e68d0957)


- 전송되는 이메일
![email](https://github.com/user-attachments/assets/37ad6780-074b-474b-ba6d-d6221af8192b)

- 이메일로 전달된 비밀번호로 로그인 성공
![변경된 비밀번호로 로그인 성공](https://github.com/user-attachments/assets/becb5a44-7106-4afa-b3a4-bd3e2780c01d)


### 🤔 리뷰 요구사항(선택)
- 비밀번호 재설정/초기화 후 사용자의 계정으로 로그인된 모든 기기에서 로그아웃하는 로직을 추가 구현할 계획입니다. 
- 위 기능을 위해 토큰의 형태를 수정해야 해서 (기기정보도 추가저장 필요) 별도의 브랜치에서 작업할 예정입니다.
