### PR TITLE
Fix/user credential validation

### DIFF
--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
@@ -76,7 +76,6 @@ public class AuthController {
         return ApiResponse.success(HttpStatus.OK, "사용 가능한 이메일입니다.");
     }
 
-
     @GetMapping("/loginid-exist-check")
     public ResponseEntity<ApiResponse<String>> isLoginIdExist(@RequestParam("loginId") String loginId) {
         boolean loginIdAlreadyExist = authService.isLoginIdAlreadyExist(loginId);

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/api/AuthController.java
@@ -1,6 +1,7 @@
 package com.howWeather.howWeather_backend.domain.member.api;
 
 import com.howWeather.howWeather_backend.domain.member.dto.*;
+import com.howWeather.howWeather_backend.domain.member.entity.LoginType;
 import com.howWeather.howWeather_backend.domain.member.entity.Member;
 import com.howWeather.howWeather_backend.domain.member.service.AuthService;
 import com.howWeather.howWeather_backend.global.Response.ApiResponse;
@@ -67,7 +68,7 @@ public class AuthController {
 
     @GetMapping("/email-exist-check")
     public ResponseEntity<ApiResponse<String>> isEmailExist(@RequestParam("email") String email) {
-        boolean emailAlreadyExist = authService.isEmailAlreadyExist(email);
+        boolean emailAlreadyExist = authService.isEmailAlreadyExist(email, LoginType.LOCAL);
 
         if (emailAlreadyExist) {
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/LoginRequestDto.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/LoginRequestDto.java
@@ -1,6 +1,8 @@
 package com.howWeather.howWeather_backend.domain.member.dto;
 
+import com.howWeather.howWeather_backend.global.custom.InvalidPrefix;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,9 +13,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequestDto {
-    @NotBlank
+    @NotBlank(message = "아이디는 필수 입력 항목입니다.")
+    @Size(min = 6, max = 20, message = "아이디는 6~20자 이내여야 합니다.")
+    @InvalidPrefix(prefixes = { "Google_", "Kakao_" }, message = "아이디는 'Google_', 'Kakao_'로 시작할 수 없습니다.")
     private String loginId;
 
-    @NotBlank
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해야 합니다.")
     private String password;
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/SignupRequestDto.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/dto/SignupRequestDto.java
@@ -1,5 +1,6 @@
 package com.howWeather.howWeather_backend.domain.member.dto;
 
+import com.howWeather.howWeather_backend.global.custom.InvalidPrefix;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ public class SignupRequestDto {
 
     @NotBlank(message = "아이디는 필수 입력 항목입니다.")
     @Size(min = 6, max = 20, message = "아이디는 6~20자 이내여야 합니다.")
+    @InvalidPrefix(prefixes = { "Google_", "Kakao_" }, message = "아이디는 'Google_', 'Kakao_'로 시작할 수 없습니다.")
     @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]*$", message = "아이디는 영문, 숫자, 특수문자만 포함할 수 있습니다.")
     private String loginId;
 

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/entity/Member.java
@@ -35,7 +35,7 @@ public class Member implements UserDetails {
     @Column(name="member_pw", nullable = false)
     private String password;
 
-    @Column(name="member_email", unique = true, nullable = false)
+    @Column(name="member_email", nullable = false)
     private String email;
 
     @Column(name="member_nickname", nullable = false)

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/entity/Member.java
@@ -139,5 +139,4 @@ public class Member implements UserDetails {
     public boolean isEnabled() {
         return !isDeleted;
     }
-
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.howWeather.howWeather_backend.domain.member.repository;
 
+import com.howWeather.howWeather_backend.domain.member.entity.LoginType;
 import com.howWeather.howWeather_backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByLoginId(String loginId);
 
     Optional<Member> findByLoginIdOrEmail(String loginId, String email);
+
+    Optional<Object> findByEmailAndLoginType(String email, LoginType loginType);
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/repository/MemberRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
-
     Optional<Member> findByLoginId(String loginId);
 
     Optional<Member> findByLoginIdOrEmail(String loginId, String email);

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -344,7 +344,6 @@ public class AuthService {
         throw new CustomException(ErrorCode.OAUTH2_TOKEN_NOT_FOUND, "OAuth2 access token을 찾을 수 없습니다.");
     }
 
-
     @Transactional
     public String resetPassword(String identifier) {
         try {

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -51,7 +51,7 @@ public class AuthService {
 
     @Transactional
     public void signup(SignupRequestDto signupRequestDto) {
-        if (isEmailAlreadyExist(signupRequestDto.getEmail())) {
+        if (isEmailAlreadyExist(signupRequestDto.getEmail(), LoginType.LOCAL)) {
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
@@ -89,9 +89,10 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public boolean isEmailAlreadyExist(String email) {
-        return memberRepository.findByEmail(email).isPresent();
+    public boolean isEmailAlreadyExist(String email, LoginType loginType) {
+        return memberRepository.findByEmailAndLoginType(email, loginType).isPresent();
     }
+
 
     @Transactional(readOnly = true)
     public boolean isLoginIdAlreadyExist(String loginId) {

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -96,7 +96,19 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public boolean isLoginIdAlreadyExist(String loginId) {
-        return memberRepository.findByLoginId(loginId).isPresent();
+        try {
+            List<String> forbiddenPrefixes = List.of("Google_", "Kakao_");
+
+            for (String prefix : forbiddenPrefixes) {
+                if (loginId.startsWith(prefix)) {
+                    throw new CustomException(ErrorCode.INVALID_SOCIAL_PREFIX_LOGIN_ID);
+                }
+            }
+
+            return memberRepository.findByLoginId(loginId).isPresent();
+        } catch (CustomException e) {
+            throw e;
+        }
     }
 
     @Transactional

--- a/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/member/service/AuthService.java
@@ -96,19 +96,15 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public boolean isLoginIdAlreadyExist(String loginId) {
-        try {
-            List<String> forbiddenPrefixes = List.of("Google_", "Kakao_");
+        List<String> forbiddenPrefixes = List.of("Google_", "Kakao_");
 
-            for (String prefix : forbiddenPrefixes) {
-                if (loginId.startsWith(prefix)) {
-                    throw new CustomException(ErrorCode.INVALID_SOCIAL_PREFIX_LOGIN_ID);
-                }
+        for (String prefix : forbiddenPrefixes) {
+            if (loginId.startsWith(prefix)) {
+                throw new CustomException(ErrorCode.INVALID_SOCIAL_PREFIX_LOGIN_ID);
             }
-
-            return memberRepository.findByLoginId(loginId).isPresent();
-        } catch (CustomException e) {
-            throw e;
         }
+
+        return memberRepository.findByLoginId(loginId).isPresent();
     }
 
     @Transactional

--- a/src/main/java/com/howWeather/howWeather_backend/global/custom/InvalidPrefix.java
+++ b/src/main/java/com/howWeather/howWeather_backend/global/custom/InvalidPrefix.java
@@ -1,0 +1,17 @@
+package com.howWeather.howWeather_backend.global.custom;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = InvalidPrefixValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InvalidPrefix {
+    String message() default "아이디는 'Google_', 'Kakao_' 등의 접두사로 시작할 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String[] prefixes(); // 금지할 접두사 목록
+}

--- a/src/main/java/com/howWeather/howWeather_backend/global/custom/InvalidPrefixValidator.java
+++ b/src/main/java/com/howWeather/howWeather_backend/global/custom/InvalidPrefixValidator.java
@@ -1,0 +1,24 @@
+package com.howWeather.howWeather_backend.global.custom;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class InvalidPrefixValidator implements ConstraintValidator<InvalidPrefix, String> {
+
+    private List<String> forbiddenPrefixes;
+
+    @Override
+    public void initialize(InvalidPrefix constraintAnnotation) {
+        forbiddenPrefixes = Arrays.asList(constraintAnnotation.prefixes());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+        return forbiddenPrefixes.stream().noneMatch(value::startsWith);
+    }
+}
+

--- a/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/howWeather/howWeather_backend/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("아이디가 존재하지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_CREDENTIALS("비밀번호가 틀렸습니다.", HttpStatus.UNAUTHORIZED),
     LOGIN_ID_ALREADY_EXISTS("이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT),
+    INVALID_SOCIAL_PREFIX_LOGIN_ID("'Kakao_', 'Google_'등 소셜 접두어는 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
     EMAIL_ALREADY_EXISTS("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
     WRONG_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     PASSWORD_MISMATCH("변경할 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #67 

### 🙌 작업 내용
- 멤버 엔티티 내 이메일 유니크 제약 조건 제거
- 이메일 중복 검사 시 같은 회원가입 방식에 한해 검사하도록 수정
- 자체 계정 생성 시 아이디 접두사로 Google_, Kakao_ 쓰지 못하게 수정

### 📸 스크린샷 (선택)
- 자체 계정 생성 시  Google_, Kakao_ 로 시작하는 아이디는 사용불가하도록 수정
![image](https://github.com/user-attachments/assets/4a0a6af2-3b0a-4d20-a67b-3044512e4d4f)
