### PR TITLE
Feature/model scheduler handle no data

### DIFF
--- a/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/schedular/ModelSchedular.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/schedular/ModelSchedular.java
@@ -1,6 +1,7 @@
 package com.howWeather.howWeather_backend.domain.ai_model.schedular;
 
 import com.howWeather.howWeather_backend.domain.ai_model.dto.AiPredictionRequestDto;
+import com.howWeather.howWeather_backend.domain.ai_model.repository.ClothingRecommendationRepository;
 import com.howWeather.howWeather_backend.domain.ai_model.service.AiInternalService;
 import com.howWeather.howWeather_backend.domain.member.entity.Member;
 import com.howWeather.howWeather_backend.domain.member.repository.MemberRepository;
@@ -15,6 +16,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.beans.factory.annotation.Value;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,10 +27,14 @@ public class ModelSchedular {
     private final MemberRepository memberRepository;
     private final AiInternalService aiInternalService;
     private final RestTemplate restTemplate;
+    private final ClothingRecommendationRepository clothingRecommendationRepository;
 
     @Value("${ai.server.url}")
     private String aiServerUrl;
 
+    /**
+     * 매일 새벽 5시에 모델 서버로 예측에 필요한 데이터를 전송합니다.
+     */
     @Scheduled(cron = "0 0 5 * * *")
     public void pushPredictionDataToAiServer() {
         try {
@@ -47,5 +53,15 @@ public class ModelSchedular {
         } catch (Exception e) {
             log.error("AI 서버 전송 실패: {}", e.getMessage(), e);
         }
+    }
+
+    /**
+     * 매일 오전 7시 30분에 오늘 이전의 의상 추천 데이터 및 예측 체감 정보를 삭제합니다.
+     */
+    @Scheduled(cron = "0 30 7 * * *")
+    public void deleteOldRecommendations() {
+        LocalDate today = LocalDate.now();
+        clothingRecommendationRepository.deleteByDateBefore(today);
+        log.info("오늘 이전의 의상 추천 데이터 및 예측 체감 정보를 모두 삭제했습니다. 기준 날짜: {}", today);
     }
 }

--- a/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/schedular/ModelSchedular.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/schedular/ModelSchedular.java
@@ -1,0 +1,51 @@
+package com.howWeather.howWeather_backend.domain.ai_model.schedular;
+
+import com.howWeather.howWeather_backend.domain.ai_model.dto.AiPredictionRequestDto;
+import com.howWeather.howWeather_backend.domain.ai_model.service.AiInternalService;
+import com.howWeather.howWeather_backend.domain.member.entity.Member;
+import com.howWeather.howWeather_backend.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ModelSchedular {
+    private final MemberRepository memberRepository;
+    private final AiInternalService aiInternalService;
+    private final RestTemplate restTemplate;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    @Scheduled(cron = "0 0 5 * * *")
+    public void pushPredictionDataToAiServer() {
+        try {
+            List<Member> members = memberRepository.findAllByIsDeletedFalse();
+
+            List<AiPredictionRequestDto> allDtos = members.stream()
+                    .filter(member -> member.getCloset() != null)
+                    .map(aiInternalService::makePredictRequest)
+                    .collect(Collectors.toList());
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<List<AiPredictionRequestDto>> requestEntity = new HttpEntity<>(allDtos, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(aiServerUrl, requestEntity, String.class);
+            log.info("AI 서버에 예측 데이터 전송 완료. 응답: {}", response.getStatusCode());
+        } catch (Exception e) {
+            log.error("AI 서버 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/service/RecommendationService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/service/RecommendationService.java
@@ -146,11 +146,7 @@ public class RecommendationService {
     }
 
     private List<ClothingRecommendation> getModelPrediction(Long id, LocalDate now) {
-        List<ClothingRecommendation> list = clothingRecommendationRepository.findByMemberIdAndDate(id, now);
-        if (list.isEmpty()) {
-            throw new CustomException(ErrorCode.NO_PREDICT_DATA);
-        }
-        return list;
+        return clothingRecommendationRepository.findByMemberIdAndDate(id, now);
     }
 
     @Transactional

--- a/src/main/java/com/howWeather/howWeather_backend/domain/weather/scheduler/WeatherScheduler.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/weather/scheduler/WeatherScheduler.java
@@ -17,46 +17,59 @@ import java.time.LocalDateTime;
 public class WeatherScheduler {
     private final WeatherService weatherService;
     private final WeatherForecastRepository weatherForecastRepository;
-    private final ClothingRecommendationRepository clothingRecommendationRepository;
 
-    @Scheduled(cron = "0 30 8 * * *", zone = "Asia/Seoul") // 오전 8시 30분
+    /**
+     * 매일 오전 8시 30분에 전국 실시간 오전 날씨 데이터를 가져옵니다.
+     */
+    @Scheduled(cron = "0 30 8 * * *", zone = "Asia/Seoul")
     public void fetchMorningWeather() {
         log.info("오전 날씨를 가져옵니다. 시간: {}", LocalDateTime.now());
         weatherService.fetchAllRegionsWeather(1);
     }
 
-    @Scheduled(cron = "0 30 13 * * *", zone = "Asia/Seoul") // 오후 1시 30분
+    /**
+     * 매일 오후 1시 30분에 전국 실시간 오후 날씨 데이터를 가져옵니다.
+     */
+    @Scheduled(cron = "0 30 13 * * *", zone = "Asia/Seoul")
     public void fetchAfternoonWeather() {
         log.info("오후 날씨를 가져옵니다. 시간: {}", LocalDateTime.now());
         weatherService.fetchAllRegionsWeather(2);
     }
 
-    @Scheduled(cron = "0 30 19 * * *", zone = "Asia/Seoul") // 저녁 7시 30분
+    /**
+     * 매일 저녁 7시 30분에 실시간 저녁 날씨 데이터를 가져옵니다.
+     */
+    @Scheduled(cron = "0 30 19 * * *", zone = "Asia/Seoul")
     public void fetchEveningWeather() {
         log.info("저녁 날씨를 가져옵니다. 시간: {}", LocalDateTime.now());
         weatherService.fetchAllRegionsWeather(3);
     }
 
-    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul") // 매일 오전 6시에 전날 데이터 삭제
+    /**
+     * 매일 오전 6시에 오늘 이전의 전국 실시간 데이터를 삭제합니다.
+     */
+    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul")
     public void deleteOldWeatherData() {
         log.info("전날 날씨 데이터를 삭제합니다. 시간: {}", LocalDateTime.now());
         weatherService.deleteOldWeather();
     }
 
-    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul") // 매일 오전 5시에 예보 데이터
+    /**
+     * 매일 오전 4시 30분에 ai 학습에 이용될 오늘의 예보 데이터를 가져옵니다.
+     */
+    @Scheduled(cron = "0 30 4 * * *", zone = "Asia/Seoul") // 매일 오전 4시 30분에 예보 데이터
     public void fetchDailyOneCallWeather() {
-        log.info("매일 오전 5시에 Forecast API로 용산구의 날씨 예보를 가져옵니다. 시간: {}", LocalDateTime.now());
+        log.info("Forecast API로 용산구의 날씨 예보를 가져옵니다. 시간: {}", LocalDateTime.now());
         weatherService.fetchHourlyForecast();
     }
 
+    /**
+     * 매일 오전 7시에 오늘 이전의 예보 데이터를 삭제합니다.
+     */
     @Scheduled(cron = "0 0 7 * * *", zone = "Asia/Seoul") // 매일 오전 7시
     public void deleteOldForecastData() {
         LocalDate today = LocalDate.now();
-
         weatherForecastRepository.deleteByForecastDateBefore(today);
         log.info("오늘 이전의 예보 데이터를 모두 삭제했습니다. 기준 날짜: {}", today);
-
-        clothingRecommendationRepository.deleteByDateBefore(today);
-        log.info("오늘 이전의 의류 추천 데이터를 모두 삭제했습니다. 기준 날짜: {}", today);
     }
 }


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #77 
- close #78 

### 🙌 작업 내용
- AI 모델의 학습에 필요한 데이터를 모델 서버 측으로 매일 전송하는 스케줄러를 구현했습니다.
- 예측 정보가 없을 경우 UX 향상을 위해 404 대신 빈 리스트를 반환하도록 했습니다.
