### PR TITLE
feat: 예측 정보 저장 시 지역 추가

### DIFF
--- a/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/entity/ClothingRecommendation.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/ai_model/entity/ClothingRecommendation.java
@@ -20,6 +20,8 @@ public class ClothingRecommendation {
 
     private Long memberId;
 
+    private String regionName;
+
     @ElementCollection
     private List<Integer> tops;
 


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #114 

### 🙌 작업 내용
- 하루 중 사용자 지역이 변경되더라도 기존에 예측한 정보를 그대로 반환할 수 있도록 합니다.