### PR TITLE
fix: 시간 순서대로 결과가 나오도록 정렬 과정 추가

### DIFF
--- a/src/main/java/com/howWeather/howWeather_backend/domain/record_calendar/service/RecordCalendarService.java
+++ b/src/main/java/com/howWeather/howWeather_backend/domain/record_calendar/service/RecordCalendarService.java
@@ -32,6 +32,7 @@ import java.time.*;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -82,6 +83,7 @@ public class RecordCalendarService {
         List<DayRecord> records = dayRecordRepository.findByMemberAndDate(member, date);
 
         return records.stream()
+                .sorted(Comparator.comparing(DayRecord::getTimeSlot))
                 .map(record -> RecordResponseDto.builder()
                         .timeSlot(record.getTimeSlot())
                         .temperature(record.getTemperature())


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #117 

### 🙌 작업 내용
- 일일 기록 조회 시 작성 순이 아니라 시간 순대로 결과를 반환하도록 수정
